### PR TITLE
fix: add validation for worker id and data center id

### DIFF
--- a/src/Snowflake.php
+++ b/src/Snowflake.php
@@ -14,6 +14,10 @@ class Snowflake
 
     protected const SEQUENCE_BITS = 12;
 
+    protected const MAX_WORKER_ID = (1 << self::WORKER_ID_BITS) - 1;
+
+    protected const MAX_DATACENTER_ID = (1 << self::DATACENTER_ID_BITS) - 1;
+
     protected int $epoch;
 
     protected int $lastTimestamp;
@@ -31,6 +35,18 @@ class Snowflake
     ) {
         if ($timestamp === null) {
             $timestamp = strtotime(self::DEFAULT_EPOCH_DATETIME);
+        }
+
+        if ($workerId > self::MAX_WORKER_ID) {
+            throw new \RangeException(
+                'Worker ID must be between 0 and ' . self::MAX_WORKER_ID
+            );
+        }
+
+        if ($datacenterId > self::MAX_DATACENTER_ID) {
+            throw new \RangeException(
+                'Data Center ID must be between 0 and ' . self::MAX_DATACENTER_ID
+            );
         }
 
         $this->epoch = $timestamp * 1000;


### PR DESCRIPTION
This PR introduces validation for the `workerId` and `datacenterId` parameters in the Snowflake class constructor. 

It ensures that both IDs are within the allowed range, enhancing the robustness and reliability of the ID generation process.

**Maximum Value for Each Bit**:
   - If you have a number with `n` bits, the number of values it can represent is \(2^n\). This includes values from `0` to \(2^n - 1\).
   - Therefore, to find the maximum value that these bits can represent, you need to take \(2^n - 1\).

**Example**:
   - For `WORKER_ID_BITS = 5`, the maximum value is:
     \[
     MAX\_WORKER\_ID = (1 << 5) - 1 = 32 - 1 = 31
     \]
   - This means that `workerId` can take values from `0` to `31` (a total of `32` values).

**Similarly for `dataCenterId`**:
   - The maximum value for `dataCenterId` is calculated in the same way.